### PR TITLE
Move polling DOM watching function into a closure

### DIFF
--- a/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js
+++ b/current/ui.apps/src/main/content/jcr_root/etc/designs/cs/brightcove/players/html5-player/js/BrightcoveExperiences.js
@@ -32,11 +32,14 @@
 
 //setVideoTrackingEvents();
 
-function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
-// use like
-r(function(){
-    createPlayers();
-});
+(function() {
+	function r(f){/in/.test(document.readyState)?setTimeout(function() { r(f) },9):f()}
+	// use like
+	r(function(){
+    	createPlayers();
+	});
+})();
+
 function createPlayers() {
     var all = document.getElementsByClassName("brightcove-container");
     for (var i = 0, max = all.length; i < max; i++) {


### PR DESCRIPTION
`r(f)` is sometimes getting destroyed by external Javascript (an injected tag from Google Tag Manager).  After `r(f)` is called three or four times as the page is loading, we would suddenly encounter the error that `r(f)` doesn't exist. Moving this function into a closure has helped eliminate the error.

This handily resolves our immediate issue of the Brightcove video player failing to instantiate. I have not explored whether there are similar scenarios for the Playlist players.

This issue was reliably reproduced in the following operating systems and browsers:

- Windows 10: All browsers
- iOS13+: Safari, Chrome

The issue could not be reproduced on macOS.

The issue was not tested on Android.